### PR TITLE
Add Annotation for ID_TypeClass

### DIFF
--- a/java/org.eclipse.set.model.planpro/model/Verweise.ecore
+++ b/java/org.eclipse.set.model.planpro/model/Verweise.ecore
@@ -17,8 +17,10 @@
          <details key="name" value="TCID_Anforderer_Element"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element Nahbedienung.ecore#//NB_Zone_Grenze"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -38,8 +40,10 @@
          <details key="name" value="TCID_Anforderung"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Block.ecore#//Block_Element Fahrstrasse.ecore#//Fstr_Fahrweg Bahnuebergang.ecore#//BUE_Einschaltung Bahnuebergang.ecore#//BUE_Ausschaltung"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -101,8 +105,10 @@
          <details key="name" value="TCID_AnhangBearbeitungsvermerk"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Basisobjekte.ecore#//Anhang Basisobjekte.ecore#//Bearbeitungsvermerk"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -122,8 +128,10 @@
          <details key="name" value="TCID_Anschluss_Element"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Bedienung.ecore#//Bedien_Standort Balisentechnik_ETCS.ecore#//Datenpunkt Ansteuerung_Element.ecore#//ESTW_Zentraleinheit Ortung.ecore#//FMA_Komponente Medien_und_Trassen.ecore#//Kabel_Verteilpunkt Balisentechnik_ETCS.ecore#//LEU_Anlage Ansteuerung_Element.ecore#//Stellelement Ansteuerung_Element.ecore#//Technik_Standort"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -500,8 +508,10 @@
          <details key="name" value="TCID_Befestigung_Bauwerk"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Geodaten.ecore#//Technischer_Punkt Geodaten.ecore#//Technischer_Bereich"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -521,8 +531,10 @@
          <details key="name" value="TCID_Beginn_Bereich"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Bahnsteig.ecore#//Bahnsteig_Kante Bahnuebergang.ecore#//BUE_Gleisbezogener_Gefahrraum Balisentechnik_ETCS.ecore#//ZUB_Streckeneigenschaft"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -542,8 +554,10 @@
          <details key="name" value="TCID_Bezugspunkt_Positionierung"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Signale.ecore#//Signal Geodaten.ecore#//Technischer_Punkt"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -836,8 +850,10 @@
          <details key="name" value="TCID_DP_Bezug_Funktional"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Bahnuebergang.ecore#//BUE_Anlage Bahnuebergang.ecore#//BUE_Einschaltung Bahnuebergang.ecore#//BUE_Kante Fahrstrasse.ecore#//Markanter_Punkt PZB.ecore#//PZB_Element Balisentechnik_ETCS.ecore#//ZUB_Streckeneigenschaft"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -878,8 +894,10 @@
          <details key="name" value="TCID_Element_Grenze"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Signale.ecore#//Signal Balisentechnik_ETCS.ecore#//Datenpunkt"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -899,8 +917,10 @@
          <details key="name" value="TCID_Element"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element Gleis.ecore#//Gleis_Abschnitt"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -920,8 +940,10 @@
          <details key="name" value="TCID_Element_Unterbringung"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Balisentechnik_ETCS.ecore#//LEU_Schaltkasten Ansteuerung_Element.ecore#//Unterbringung"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -941,8 +963,10 @@
          <details key="name" value="TCID_Energie_Eingang"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Bahnuebergang.ecore#//BUE_Anlage Balisentechnik_ETCS.ecore#//EV_Modul Ansteuerung_Element.ecore#//ESTW_Zentraleinheit PZB.ecore#//PZB_Element"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -962,8 +986,10 @@
          <details key="name" value="TCID_Energie"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Ansteuerung_Element.ecore#//ESTW_Zentraleinheit Balisentechnik_ETCS.ecore#//EV_Modul"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1235,8 +1261,10 @@
          <details key="name" value="TCID_Fortschaltung_Start"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ortung.ecore#//FMA_Anlage Signale.ecore#//Signal"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1445,8 +1473,10 @@
          <details key="name" value="TCID_GEO_Art"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Geodaten.ecore#//TOP_Kante Geodaten.ecore#//Strecke"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1634,8 +1664,10 @@
          <details key="name" value="TCID_Handschalt_Wirkfunktion"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Bahnuebergang.ecore#//BUE_Anlage Bahnuebergang.ecore#//BUE_Einschaltung Bahnuebergang.ecore#//BUE_Ausschaltung"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1676,8 +1708,10 @@
          <details key="name" value="TCID_Information_Eingang"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Bahnuebergang.ecore#//BUE_Anlage Balisentechnik_ETCS.ecore#//LEU_Anlage Balisentechnik_ETCS.ecore#//LEU_Modul PZB.ecore#//PZB_Element Signale.ecore#//Signal Weichen_und_Gleissperren.ecore#//W_Kr_Anlage"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1697,8 +1731,10 @@
          <details key="name" value="TCID_Information_Primaer"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Ansteuerung_Element.ecore#//ESTW_Zentraleinheit"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1718,8 +1754,10 @@
          <details key="name" value="TCID_Komponente_Programmiert"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Balisentechnik_ETCS.ecore#//Balise Balisentechnik_ETCS.ecore#//LEU_Modul"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1844,8 +1882,10 @@
          <details key="name" value="TCID_LEU_Bezug_Funktional"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Bahnuebergang.ecore#//BUE_Anlage Signale.ecore#//Signal Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1907,8 +1947,10 @@
          <details key="name" value="TCID_Markante_Stelle"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Balisentechnik_ETCS.ecore#//Datenpunkt Signale.ecore#//Signal Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Komponente Fahrstrasse.ecore#//Sonstiger_Punkt Ortung.ecore#//FMA_Komponente"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1928,8 +1970,10 @@
          <details key="name" value="TCID_Markanter_Punkt_Gleis_Abschluss"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Fahrstrasse.ecore#//Markanter_Punkt Weichen_und_Gleissperren.ecore#//Gleis_Abschluss"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -1970,8 +2014,10 @@
          <details key="name" value="TCID_NB_Element"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Signale.ecore#//Signal Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element Schluesselabhaengigkeiten.ecore#//Schluesselsperre"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2159,8 +2205,10 @@
          <details key="name" value="TCID_PZB_Element_Bezugspunkt"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Signale.ecore#//Signal Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2243,8 +2291,10 @@
          <details key="name" value="TCID_Quellelement"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Bahnuebergang.ecore#//BUE_Anlage Balisentechnik_ETCS.ecore#//EV_Modul Ansteuerung_Element.ecore#//ESTW_Zentraleinheit PZB.ecore#//PZB_Element"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2327,8 +2377,10 @@
          <details key="name" value="TCID_Schalter"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ortung.ecore#//FMA_Anlage Ortung.ecore#//FMA_Komponente Ortung.ecore#//Zugeinwirkung"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2642,8 +2694,10 @@
          <details key="name" value="TCID_Stellwerk"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//ESTW_Zentraleinheit Ansteuerung_Element.ecore#//Aussenelementansteuerung"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2873,8 +2927,10 @@
          <details key="name" value="TCID_Uebertragungsweg_Nach"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Bedienung.ecore#//Bedien_Bezirk Bedienung.ecore#//Bedien_Zentrale Ansteuerung_Element.ecore#//ESTW_Zentraleinheit Ansteuerung_Element.ecore#//Stellelement Zugnummernmeldeanlage.ecore#//ZN_ZBS"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2894,8 +2950,10 @@
          <details key="name" value="TCID_Uebertragungsweg_Von"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Aussenelementansteuerung Bedienung.ecore#//Bedien_Bezirk Bedienung.ecore#//Bedien_Zentrale Ansteuerung_Element.ecore#//ESTW_Zentraleinheit Ansteuerung_Element.ecore#//Stellelement Zugnummernmeldeanlage.ecore#//ZN_ZBS"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2915,8 +2973,10 @@
          <details key="name" value="TCID_Umfahrpunkt"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element Gleis.ecore#//Gleis_Abschnitt"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -2957,8 +3017,10 @@
          <details key="name" value="TCID_Unterbringung_Technik"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Ansteuerung_Element.ecore#//Technik_Standort Ansteuerung_Element.ecore#//Unterbringung"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -3020,8 +3082,10 @@
          <details key="name" value="TCID_Verknuepftes_Element"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Signale.ecore#//Signal Weichen_und_Gleissperren.ecore#//W_Kr_Gsp_Element"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"
@@ -3146,8 +3210,10 @@
          <details key="name" value="TCID_Ziel"/>
          <details key="kind" value="elementOnly"/>
       </eAnnotations>
-      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                           xmlns:func="localhost/function"
+      <eAnnotations xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
+                    source="planpro/id_reference"
+                    references="Signale.ecore#//Signal Fahrstrasse.ecore#//Markanter_Punkt"/>
+      <eStructuralFeatures xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="localhost/function"
                            xsi:type="ecore:EReference"
                            name="value"
                            eType="ecore:EClass Basisobjekte.ecore#//Basis_Objekt"

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Anforderer_Element_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Anforderer_Element_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Anforderer_Element_TypeClass()
  * @model extendedMetaData="name='TCID_Anforderer_Element' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Anforderer_Element_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Anforderung_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Anforderung_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Anforderung_TypeClass()
  * @model extendedMetaData="name='TCID_Anforderung' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Anforderung_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_AnhangBearbeitungsvermerk_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_AnhangBearbeitungsvermerk_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_AnhangBearbeitungsvermerk_TypeClass()
  * @model extendedMetaData="name='TCID_AnhangBearbeitungsvermerk' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_AnhangBearbeitungsvermerk_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Anschluss_Element_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Anschluss_Element_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Anschluss_Element_TypeClass()
  * @model extendedMetaData="name='TCID_Anschluss_Element' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Anschluss_Element_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Befestigung_Bauwerk_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Befestigung_Bauwerk_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Befestigung_Bauwerk_TypeClass()
  * @model extendedMetaData="name='TCID_Befestigung_Bauwerk' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Befestigung_Bauwerk_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Beginn_Bereich_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Beginn_Bereich_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Beginn_Bereich_TypeClass()
  * @model extendedMetaData="name='TCID_Beginn_Bereich' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Beginn_Bereich_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Bezugspunkt_Positionierung_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Bezugspunkt_Positionierung_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Bezugspunkt_Positionierung_TypeClass()
  * @model extendedMetaData="name='TCID_Bezugspunkt_Positionierung' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Bezugspunkt_Positionierung_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_DP_Bezug_Funktional_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_DP_Bezug_Funktional_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_DP_Bezug_Funktional_TypeClass()
  * @model extendedMetaData="name='TCID_DP_Bezug_Funktional' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_DP_Bezug_Funktional_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Element_Grenze_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Element_Grenze_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Element_Grenze_TypeClass()
  * @model extendedMetaData="name='TCID_Element_Grenze' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Element_Grenze_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Element_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Element_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Element_TypeClass()
  * @model extendedMetaData="name='TCID_Element' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Element_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Element_Unterbringung_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Element_Unterbringung_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Element_Unterbringung_TypeClass()
  * @model extendedMetaData="name='TCID_Element_Unterbringung' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Element_Unterbringung_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Energie_Eingang_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Energie_Eingang_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Energie_Eingang_TypeClass()
  * @model extendedMetaData="name='TCID_Energie_Eingang' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Energie_Eingang_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Energie_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Energie_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Energie_TypeClass()
  * @model extendedMetaData="name='TCID_Energie' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Energie_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Fortschaltung_Start_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Fortschaltung_Start_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Fortschaltung_Start_TypeClass()
  * @model extendedMetaData="name='TCID_Fortschaltung_Start' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Fortschaltung_Start_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_GEO_Art_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_GEO_Art_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_GEO_Art_TypeClass()
  * @model extendedMetaData="name='TCID_GEO_Art' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_GEO_Art_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Handschalt_Wirkfunktion_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Handschalt_Wirkfunktion_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Handschalt_Wirkfunktion_TypeClass()
  * @model extendedMetaData="name='TCID_Handschalt_Wirkfunktion' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Handschalt_Wirkfunktion_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Information_Eingang_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Information_Eingang_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Information_Eingang_TypeClass()
  * @model extendedMetaData="name='TCID_Information_Eingang' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Information_Eingang_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Information_Primaer_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Information_Primaer_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Information_Primaer_TypeClass()
  * @model extendedMetaData="name='TCID_Information_Primaer' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Information_Primaer_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Komponente_Programmiert_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Komponente_Programmiert_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Komponente_Programmiert_TypeClass()
  * @model extendedMetaData="name='TCID_Komponente_Programmiert' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Komponente_Programmiert_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_LEU_Bezug_Funktional_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_LEU_Bezug_Funktional_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_LEU_Bezug_Funktional_TypeClass()
  * @model extendedMetaData="name='TCID_LEU_Bezug_Funktional' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_LEU_Bezug_Funktional_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Markante_Stelle_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Markante_Stelle_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Markante_Stelle_TypeClass()
  * @model extendedMetaData="name='TCID_Markante_Stelle' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Markante_Stelle_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Markanter_Punkt_Gleis_Abschluss_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Markanter_Punkt_Gleis_Abschluss_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Markanter_Punkt_Gleis_Abschluss_TypeClass()
  * @model extendedMetaData="name='TCID_Markanter_Punkt_Gleis_Abschluss' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Markanter_Punkt_Gleis_Abschluss_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_NB_Element_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_NB_Element_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_NB_Element_TypeClass()
  * @model extendedMetaData="name='TCID_NB_Element' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_NB_Element_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_PZB_Element_Bezugspunkt_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_PZB_Element_Bezugspunkt_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_PZB_Element_Bezugspunkt_TypeClass()
  * @model extendedMetaData="name='TCID_PZB_Element_Bezugspunkt' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_PZB_Element_Bezugspunkt_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Quellelement_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Quellelement_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Quellelement_TypeClass()
  * @model extendedMetaData="name='TCID_Quellelement' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Quellelement_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Schalter_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Schalter_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Schalter_TypeClass()
  * @model extendedMetaData="name='TCID_Schalter' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Schalter_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Stellwerk_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Stellwerk_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Stellwerk_TypeClass()
  * @model extendedMetaData="name='TCID_Stellwerk' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Stellwerk_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Uebertragungsweg_Nach_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Uebertragungsweg_Nach_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Uebertragungsweg_Nach_TypeClass()
  * @model extendedMetaData="name='TCID_Uebertragungsweg_Nach' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Uebertragungsweg_Nach_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Uebertragungsweg_Von_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Uebertragungsweg_Von_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Uebertragungsweg_Von_TypeClass()
  * @model extendedMetaData="name='TCID_Uebertragungsweg_Von' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Uebertragungsweg_Von_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Umfahrpunkt_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Umfahrpunkt_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Umfahrpunkt_TypeClass()
  * @model extendedMetaData="name='TCID_Umfahrpunkt' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Umfahrpunkt_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Unterbringung_Technik_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Unterbringung_Technik_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Unterbringung_Technik_TypeClass()
  * @model extendedMetaData="name='TCID_Unterbringung_Technik' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Unterbringung_Technik_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Verknuepftes_Element_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Verknuepftes_Element_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Verknuepftes_Element_TypeClass()
  * @model extendedMetaData="name='TCID_Verknuepftes_Element' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Verknuepftes_Element_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Ziel_TypeClass.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/ID_Ziel_TypeClass.java
@@ -27,6 +27,7 @@ import org.eclipse.set.model.planpro.Basisobjekte.Basis_Objekt;
  *
  * @see org.eclipse.set.model.planpro.Verweise.VerweisePackage#getID_Ziel_TypeClass()
  * @model extendedMetaData="name='TCID_Ziel' kind='elementOnly'"
+ *        annotation="planpro/id_reference"
  * @generated
  */
 public interface ID_Ziel_TypeClass extends Zeiger_TypeClass {

--- a/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/impl/VerweisePackageImpl.java
+++ b/java/org.eclipse.set.model.planpro/src/org/eclipse/set/model/planpro/Verweise/impl/VerweisePackageImpl.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.set.model.planpro.Verweise.impl;
 
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
@@ -8116,6 +8117,8 @@ public class VerweisePackageImpl extends EPackageImpl implements VerweisePackage
 		createGenModelAnnotations();
 		// http:///org/eclipse/emf/ecore/util/ExtendedMetaData
 		createExtendedMetaDataAnnotations();
+		// planpro/id_reference
+		createId_referenceAnnotations();
 	}
 
 	/**
@@ -8130,7 +8133,7 @@ public class VerweisePackageImpl extends EPackageImpl implements VerweisePackage
 		  (this,
 		   source,
 		   new String[] {
-			   "documentation", "Dieses Werk ist lizenziert unter der Open Source Lizenz RailPL V1.0.\n\nWeitere Informationen zur Lizenz finden Sie auf\nhttp://www.dbnetze.com/planpro\n\nInhalt der Datei:\nXML Schema f\u00fcr PlanPro Schnittstelle.\n\nBei Fragen zum Schema wenden Sie sich bitte an planpro@deutschebahn.com\n\n--------------------------------------------------------------------------------\n\nThis Document is licensed under the open source license RailPL V1.0.\n\nMore information about the license can be found on\nhttp://www.dbnetze.com/planpro\n\nContents of the file:\nXML Schema for PlanPro interface.\nDieses Werk ist lizenziert unter der Open Source Lizenz RailPL V1.0.\n\nWeitere Informationen zur Lizenz finden Sie auf\nhttp://www.dbnetze.com/planpro\n\nInhalt der Datei:\nXML Schema f\u00fcr PlanPro Schnittstelle.\n\nBei Fragen zum Schema wenden Sie sich bitte an planpro@deutschebahn.com\n\n--------------------------------------------------------------------------------\n\nThis Document is licensed under the open source license RailPL V1.0.\n\nMore information about the license can be found on\nhttp://www.dbnetze.com/planpro\n\nContents of the file:\nXML Schema for PlanPro interface."
+			   "documentation", "Dieses Werk ist lizenziert unter der Open Source Lizenz RailPL V1.0.\n\nWeitere Informationen zur Lizenz finden Sie auf\nhttp://www.dbnetze.com/planpro\n\nInhalt der Datei:\nXML Schema f\u00fcr PlanPro Schnittstelle.\n\nBei Fragen zum Schema wenden Sie sich bitte an planpro@deutschebahn.com\n\n--------------------------------------------------------------------------------\n\nThis Document is licensed under the open source license RailPL V1.0.\n\nMore information about the license can be found on\nhttp://www.dbnetze.com/planpro\n\nContents of the file:\nXML Schema for PlanPro interface.\r\nDieses Werk ist lizenziert unter der Open Source Lizenz RailPL V1.0.\n\nWeitere Informationen zur Lizenz finden Sie auf\nhttp://www.dbnetze.com/planpro\n\nInhalt der Datei:\nXML Schema f\u00fcr PlanPro Schnittstelle.\n\nBei Fragen zum Schema wenden Sie sich bitte an planpro@deutschebahn.com\n\n--------------------------------------------------------------------------------\n\nThis Document is licensed under the open source license RailPL V1.0.\n\nMore information about the license can be found on\nhttp://www.dbnetze.com/planpro\n\nContents of the file:\nXML Schema for PlanPro interface."
 		   });
 	}
 
@@ -9289,6 +9292,354 @@ public class VerweisePackageImpl extends EPackageImpl implements VerweisePackage
 		   new String[] {
 			   "name", "TCID_Zweites_Haltfallkriterium",
 			   "kind", "elementOnly"
+		   });
+	}
+
+	/**
+	 * Initializes the annotations for <b>planpro/id_reference</b>.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void createId_referenceAnnotations() {
+		String source = "planpro/id_reference";
+		addAnnotation
+		  (iD_Anforderer_Element_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element"),
+			 URI.createURI(NahbedienungPackage.eNS_URI).appendFragment("//NB_Zone_Grenze")
+		   });
+		addAnnotation
+		  (iD_Anforderung_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(BlockPackage.eNS_URI).appendFragment("//Block_Element"),
+			 URI.createURI(FahrstrassePackage.eNS_URI).appendFragment("//Fstr_Fahrweg"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Einschaltung"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Ausschaltung")
+		   });
+		addAnnotation
+		  (iD_AnhangBearbeitungsvermerk_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(BasisobjektePackage.eNS_URI).appendFragment("//Anhang"),
+			 URI.createURI(BasisobjektePackage.eNS_URI).appendFragment("//Bearbeitungsvermerk")
+		   });
+		addAnnotation
+		  (iD_Anschluss_Element_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(BedienungPackage.eNS_URI).appendFragment("//Bedien_Standort"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//Datenpunkt"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(OrtungPackage.eNS_URI).appendFragment("//FMA_Komponente"),
+			 URI.createURI(Medien_und_TrassenPackage.eNS_URI).appendFragment("//Kabel_Verteilpunkt"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//LEU_Anlage"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Stellelement"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Technik_Standort")
+		   });
+		addAnnotation
+		  (iD_Befestigung_Bauwerk_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(GeodatenPackage.eNS_URI).appendFragment("//Technischer_Punkt"),
+			 URI.createURI(GeodatenPackage.eNS_URI).appendFragment("//Technischer_Bereich")
+		   });
+		addAnnotation
+		  (iD_Beginn_Bereich_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(BahnsteigPackage.eNS_URI).appendFragment("//Bahnsteig_Kante"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Gleisbezogener_Gefahrraum"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//ZUB_Streckeneigenschaft")
+		   });
+		addAnnotation
+		  (iD_Bezugspunkt_Positionierung_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(GeodatenPackage.eNS_URI).appendFragment("//Technischer_Punkt")
+		   });
+		addAnnotation
+		  (iD_DP_Bezug_Funktional_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Anlage"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Einschaltung"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Kante"),
+			 URI.createURI(FahrstrassePackage.eNS_URI).appendFragment("//Markanter_Punkt"),
+			 URI.createURI(PZBPackage.eNS_URI).appendFragment("//PZB_Element"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//ZUB_Streckeneigenschaft")
+		   });
+		addAnnotation
+		  (iD_Element_Grenze_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//Datenpunkt")
+		   });
+		addAnnotation
+		  (iD_Element_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element"),
+			 URI.createURI(GleisPackage.eNS_URI).appendFragment("//Gleis_Abschnitt")
+		   });
+		addAnnotation
+		  (iD_Element_Unterbringung_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//LEU_Schaltkasten"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Unterbringung")
+		   });
+		addAnnotation
+		  (iD_Energie_Eingang_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Anlage"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//EV_Modul"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(PZBPackage.eNS_URI).appendFragment("//PZB_Element")
+		   });
+		addAnnotation
+		  (iD_Energie_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//EV_Modul")
+		   });
+		addAnnotation
+		  (iD_Fortschaltung_Start_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(OrtungPackage.eNS_URI).appendFragment("//FMA_Anlage"),
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal")
+		   });
+		addAnnotation
+		  (iD_GEO_Art_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(GeodatenPackage.eNS_URI).appendFragment("//TOP_Kante"),
+			 URI.createURI(GeodatenPackage.eNS_URI).appendFragment("//Strecke")
+		   });
+		addAnnotation
+		  (iD_Handschalt_Wirkfunktion_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Anlage"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Einschaltung"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Ausschaltung")
+		   });
+		addAnnotation
+		  (iD_Information_Eingang_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Anlage"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//LEU_Anlage"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//LEU_Modul"),
+			 URI.createURI(PZBPackage.eNS_URI).appendFragment("//PZB_Element"),
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Anlage")
+		   });
+		addAnnotation
+		  (iD_Information_Primaer_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit")
+		   });
+		addAnnotation
+		  (iD_Komponente_Programmiert_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//Balise"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//LEU_Modul")
+		   });
+		addAnnotation
+		  (iD_LEU_Bezug_Funktional_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Anlage"),
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element")
+		   });
+		addAnnotation
+		  (iD_Markante_Stelle_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//Datenpunkt"),
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Komponente"),
+			 URI.createURI(FahrstrassePackage.eNS_URI).appendFragment("//Sonstiger_Punkt"),
+			 URI.createURI(OrtungPackage.eNS_URI).appendFragment("//FMA_Komponente")
+		   });
+		addAnnotation
+		  (iD_Markanter_Punkt_Gleis_Abschluss_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(FahrstrassePackage.eNS_URI).appendFragment("//Markanter_Punkt"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//Gleis_Abschluss")
+		   });
+		addAnnotation
+		  (iD_NB_Element_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element"),
+			 URI.createURI(SchluesselabhaengigkeitenPackage.eNS_URI).appendFragment("//Schluesselsperre")
+		   });
+		addAnnotation
+		  (iD_PZB_Element_Bezugspunkt_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element")
+		   });
+		addAnnotation
+		  (iD_Quellelement_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(BahnuebergangPackage.eNS_URI).appendFragment("//BUE_Anlage"),
+			 URI.createURI(Balisentechnik_ETCSPackage.eNS_URI).appendFragment("//EV_Modul"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(PZBPackage.eNS_URI).appendFragment("//PZB_Element")
+		   });
+		addAnnotation
+		  (iD_Schalter_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(OrtungPackage.eNS_URI).appendFragment("//FMA_Anlage"),
+			 URI.createURI(OrtungPackage.eNS_URI).appendFragment("//FMA_Komponente"),
+			 URI.createURI(OrtungPackage.eNS_URI).appendFragment("//Zugeinwirkung")
+		   });
+		addAnnotation
+		  (iD_Stellwerk_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung")
+		   });
+		addAnnotation
+		  (iD_Uebertragungsweg_Nach_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(BedienungPackage.eNS_URI).appendFragment("//Bedien_Bezirk"),
+			 URI.createURI(BedienungPackage.eNS_URI).appendFragment("//Bedien_Zentrale"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Stellelement"),
+			 URI.createURI(ZugnummernmeldeanlagePackage.eNS_URI).appendFragment("//ZN_ZBS")
+		   });
+		addAnnotation
+		  (iD_Uebertragungsweg_Von_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Aussenelementansteuerung"),
+			 URI.createURI(BedienungPackage.eNS_URI).appendFragment("//Bedien_Bezirk"),
+			 URI.createURI(BedienungPackage.eNS_URI).appendFragment("//Bedien_Zentrale"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//ESTW_Zentraleinheit"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Stellelement"),
+			 URI.createURI(ZugnummernmeldeanlagePackage.eNS_URI).appendFragment("//ZN_ZBS")
+		   });
+		addAnnotation
+		  (iD_Umfahrpunkt_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element"),
+			 URI.createURI(GleisPackage.eNS_URI).appendFragment("//Gleis_Abschnitt")
+		   });
+		addAnnotation
+		  (iD_Unterbringung_Technik_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Technik_Standort"),
+			 URI.createURI(Ansteuerung_ElementPackage.eNS_URI).appendFragment("//Unterbringung")
+		   });
+		addAnnotation
+		  (iD_Verknuepftes_Element_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(Weichen_und_GleissperrenPackage.eNS_URI).appendFragment("//W_Kr_Gsp_Element")
+		   });
+		addAnnotation
+		  (iD_Ziel_TypeClassEClass,
+		   source,
+		   new String[] {
+		   },
+		   new URI[] {
+			 URI.createURI(SignalePackage.eNS_URI).appendFragment("//Signal"),
+			 URI.createURI(FahrstrassePackage.eNS_URI).appendFragment("//Markanter_Punkt")
 		   });
 	}
 


### PR DESCRIPTION
The Ecore model does not support multiple reference types for a single object, this PR adds an annotation to the ID_Typeclass that lists the reference types associated with the object.